### PR TITLE
Run the Rust code with optimizations

### DIFF
--- a/1.7/s2i/bin/run
+++ b/1.7/s2i/bin/run
@@ -2,4 +2,4 @@
 
 set -e
 
-cargo run
+cargo run --release


### PR DESCRIPTION
The compiled Rust code should always be done with optimizations on
either by passing `--release` to Cargo or `-O` to `rustc` (except during
development or debugging):

https://www.rust-lang.org/faq.html#why-is-my-program-slow

I don't have a handy reference, but running unoptimized Rust is orders
of magnitude slower (or as the community is fond of saying "as slow as
Ruby").